### PR TITLE
Add specific listener support for filter policies

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -133,50 +133,37 @@ func getFilterForPathAndUID(path string, uid int) *ServerClientFilterConfig {
 }
 
 func hasReplacementCommand(cmd string, replacements map[string]string) (string, bool) {
-	log.Print("maybeReplaceCommand\n")
 	replacement, ok := replacements[cmd]
 	if ok {
-		log.Printf("%v true", replacement)
 		return replacement, true
 	}
-	log.Printf("%v false", replacement)
 	return cmd, false
 }
 
 func hasReplacementPrefix(cmd string, replacements map[string]string) (string, bool) {
-	log.Print("hasReplacementPrefix")
 	for prefix, replacement := range replacements {
-		log.Printf("does cmd %s contain prefix %s\n", cmd, prefix)
 		if strings.HasPrefix(cmd, prefix) {
-			log.Print("true")
 			return replacement, true
 		}
 	}
-	log.Print("false")
 	return cmd, false
 }
 
 func isCommandAllowed(cmd string, allowed []string) bool {
-	log.Print("isCommandAllowed")
 	for i := 0; i < len(allowed); i++ {
 		if cmd == allowed[i] {
-			log.Print("true")
 			return true
 		}
 	}
-	log.Print("false")
 	return false
 }
 
 func isPrefixAllowed(cmd string, allowed []string) bool {
-	log.Print("isPrefixAllowed")
 	for i := 0; i < len(allowed); i++ {
 		if strings.HasPrefix(cmd, allowed[i]) {
-			log.Print("true")
 			return true
 		}
 	}
-	log.Print("false")
 	return false
 }
 

--- a/filters/tbb.json
+++ b/filters/tbb.json
@@ -1,0 +1,15 @@
+{
+    "AuthNetAddr" : "tcp",
+    "AuthAddr" : "127.0.0.1:9051",
+    "exec-path": "/srv/oz/rootfs/home/user/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser/firefox",
+    "client-allowed" : ["SIGNAL NEWNYM","GETINFO net/listeners/socks", "GETCONF UseBridges", "GETCONF Bridge",
+			"GETCONF Socks4Proxy", "GETCONF Socks5Proxy", "GETCONF HTTPSProxy",
+		       "GETCONF ReachableAddresses"],
+    "client-allowed-prefixes" : [],
+    "client-replacements" : {},
+    "client-replacement-prefixes" : {"AUTHENTICATE":"AUTHENTICATE"},
+    "server-allowed" : ["250 OK", "250-net/listeners/socks=\"127.0.0.1:9050\"", "250 UseBridges=0",
+		       "250 ReachableAddresses"],
+    "server-allowed-prefixes" : [],
+    "server-replacement-prefixes" : {"650 STREAM": "650 STREAM SUCCEEDED 1 127.0.0.1:1234"}
+}

--- a/filters/tbb.json
+++ b/filters/tbb.json
@@ -5,11 +5,11 @@
     "client-allowed" : ["SIGNAL NEWNYM","GETINFO net/listeners/socks", "GETCONF UseBridges", "GETCONF Bridge",
 			"GETCONF Socks4Proxy", "GETCONF Socks5Proxy", "GETCONF HTTPSProxy",
 		       "GETCONF ReachableAddresses"],
-    "client-allowed-prefixes" : [],
+    "client-allowed-prefixes" : ["AUTHENTICATE"],
     "client-replacements" : {},
-    "client-replacement-prefixes" : {"AUTHENTICATE":"AUTHENTICATE"},
+    "client-replacement-prefixes" : {},
     "server-allowed" : ["250 OK", "250-net/listeners/socks=\"127.0.0.1:9050\"", "250 UseBridges=0",
 		       "250 ReachableAddresses"],
-    "server-allowed-prefixes" : [],
-    "server-replacement-prefixes" : {"650 STREAM": "650 STREAM SUCCEEDED 1 127.0.0.1:1234"}
+    "server-allowed-prefixes" : ["650 STREAM"],
+    "server-replacement-prefixes" : {}
 }

--- a/roflcoptor_testing_config.json
+++ b/roflcoptor_testing_config.json
@@ -1,7 +1,7 @@
 {
     "LogFile" : "-",
     "FiltersPath" : "./filters",
-    "ListenTCPPort" : "8851",
+    "ListenTCPPort" : "9051",
     "ListenIP" : "127.0.0.1",
     "TorControlSocketPath" : "/var/run/tor/control"
 }

--- a/session.go
+++ b/session.go
@@ -67,7 +67,7 @@ func (p *ProxyListener) AuthListener(listener net.Listener, policy *ServerClient
 		log.Printf("CONNECTION received %s:%s -> %s:%s\n", conn.RemoteAddr().Network(), conn.RemoteAddr().String(), conn.LocalAddr().Network(), conn.LocalAddr().String())
 
 		// Create the appropriate session instance.
-		s := NewAuthProxySession(conn, policy, p.watch)
+		s := NewAuthProxySession(conn, p.cfg, policy, p.watch)
 		go s.sessionWorker()
 	}
 }
@@ -147,8 +147,9 @@ type ProxySession struct {
 
 // NewAuthProxySession creates an instance of ProxySession that is prepared with a previously
 // authenticated policy.
-func NewAuthProxySession(conn net.Conn, policy *ServerClientFilterConfig, watch bool) *ProxySession {
+func NewAuthProxySession(conn net.Conn, cfg *RoflcoptorConfig, policy *ServerClientFilterConfig, watch bool) *ProxySession {
 	s := ProxySession{
+		cfg:           cfg,
 		policy:        policy,
 		watch:         watch,
 		appConn:       conn,

--- a/session.go
+++ b/session.go
@@ -253,10 +253,6 @@ func (s *ProxySession) sessionWorker() {
 			log.Printf("proc info query failure; connection from %s aborted: %s\n", clientAddr, err)
 			return
 		}
-		if s.policy == nil {
-			log.Print("failed to find a policy, connection proxy refusing")
-			return
-		}
 	} else {
 		log.Printf("Applying existing policy %v\n", s.policy)
 		procInfo := s.getProcInfo()
@@ -270,18 +266,19 @@ func (s *ProxySession) sessionWorker() {
 			return
 		}
 	}
-
-	s.clientFilterPolicy = &FilterConfig{
-		Allowed:             s.policy.ClientAllowed,
-		AllowedPrefixes:     s.policy.ClientAllowedPrefixes,
-		Replacements:        s.policy.ClientReplacements,
-		ReplacementPrefixes: s.policy.ClientReplacementPrefixes,
-	}
-	s.serverFilterPolicy = &FilterConfig{
-		Allowed:             s.policy.ServerAllowed,
-		AllowedPrefixes:     s.policy.ServerAllowedPrefixes,
-		Replacements:        s.policy.ServerReplacements,
-		ReplacementPrefixes: s.policy.ServerReplacementPrefixes,
+	if s.policy != nil {
+		s.clientFilterPolicy = &FilterConfig{
+			Allowed:             s.policy.ClientAllowed,
+			AllowedPrefixes:     s.policy.ClientAllowedPrefixes,
+			Replacements:        s.policy.ClientReplacements,
+			ReplacementPrefixes: s.policy.ClientReplacementPrefixes,
+		}
+		s.serverFilterPolicy = &FilterConfig{
+			Allowed:             s.policy.ServerAllowed,
+			AllowedPrefixes:     s.policy.ServerAllowedPrefixes,
+			Replacements:        s.policy.ServerReplacements,
+			ReplacementPrefixes: s.policy.ServerReplacementPrefixes,
+		}
 	}
 
 	// Authenticate with the real control port

--- a/session.go
+++ b/session.go
@@ -201,12 +201,10 @@ func (s *ProxySession) getProcInfo() *procsnitch.Info {
 // when we fail to lookup the proc info, we return nil and an error.
 func (s *ProxySession) getFilterPolicy() (*ServerClientFilterConfig, error) {
 	procInfo := s.getProcInfo()
-	log.Printf("proc exec path: %s\n", procInfo.ExePath)
 	if procInfo == nil {
 		s.appConn.Close()
 		return nil, fmt.Errorf("Could not find process information for connection %s:%s", s.appConn.LocalAddr().Network(), s.appConn.LocalAddr().String())
 	}
-
 	filter := getFilterForPathAndUID(procInfo.ExePath, procInfo.UID)
 	if filter == nil {
 		filter = getFilterForPath(procInfo.ExePath)


### PR DESCRIPTION
This allows for one listener per policy... where a particular
listener always applies the same policy.
