### PR TITLE
Add clean shutdown code path to cleanup connection sockets

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"sync"
 )
 
 // RoflcoptorConfig is used to configure our
@@ -93,8 +92,7 @@ func main() {
 	sigKillChan := make(chan os.Signal, 1)
 	signal.Notify(sigKillChan, os.Interrupt, os.Kill)
 
-	var wg sync.WaitGroup
-	proxyListener := NewProxyListener(config, &wg, watchMode)
+	proxyListener := NewProxyListener(config, watchMode)
 	proxyListener.StartListeners()
 	defer proxyListener.StopListeners()
 	for {

--- a/session.go
+++ b/session.go
@@ -135,7 +135,6 @@ func (r RealProcInfo) LookupUNIXSocketProcess(socketFile string) *procsnitch.Inf
 type ProxyListener struct {
 	cfg            *RoflcoptorConfig
 	watch          bool
-	wg             *sync.WaitGroup
 	services       []*MortalListener
 	authedServices []*MortalListener
 	onionDenyAddrs []AddrString
@@ -146,10 +145,9 @@ type ProxyListener struct {
 
 // NewProxyListener creates a new ProxyListener given
 // a configuration structure.
-func NewProxyListener(cfg *RoflcoptorConfig, wg *sync.WaitGroup, watch bool) *ProxyListener {
+func NewProxyListener(cfg *RoflcoptorConfig, watch bool) *ProxyListener {
 	p := ProxyListener{
 		cfg:        cfg,
-		wg:         wg,
 		watch:      watch,
 		procInfo:   RealProcInfo{},
 		policyList: NewPolicyList(),

--- a/session_test.go
+++ b/session_test.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -115,12 +114,11 @@ func TestProxyListenerSession(t *testing.T) {
 		panic(fmt.Sprintf("Unable to load filters: %s\n", err))
 	}
 
-	wg := sync.WaitGroup{}
 	watch := false
 
 	accListener := NewAccumulatingListener(config.TorControlNet, config.TorControlAddress)
 	go accListener.AcceptLoop()
-	proxyListener := NewProxyListener(&config, &wg, watch)
+	proxyListener := NewProxyListener(&config, watch)
 	proxyListener.procInfo = MockProcInfo{}
 	proxyListener.StartListeners()
 

--- a/session_test.go
+++ b/session_test.go
@@ -4,11 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
+	"log"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/subgraph/go-procsnitch"
 	"github.com/yawning/bulb"
@@ -141,4 +144,56 @@ func TestProxyListenerSession(t *testing.T) {
 		t.Errorf("accumulated control commands don't match", err)
 		t.Fail()
 	}
+}
+
+func echoConnection(conn net.Conn) error {
+	if _, err := io.Copy(conn, conn); err != nil {
+		log.Println(err.Error())
+		return err
+	}
+	return nil
+}
+
+func TestMortalListener(t *testing.T) {
+	network := "tcp"
+	address := "127.0.0.1:5388"
+	l := NewMortalListener(network, address, echoConnection)
+	defer l.Stop()
+	go l.Start()
+
+	time.Sleep(time.Second)
+
+	// In this test, we start 10 clients, each making a single connection
+	// to the server. Then each will write 10 messages to the server, and
+	// read the same 10 messages back. After that the client quits.
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			defer func() {
+				log.Printf("Quiting client #%d", id)
+			}()
+
+			conn, err := net.Dial("tcp", "127.0.0.1:5388")
+			if err != nil {
+				log.Println(err.Error())
+				return
+			}
+			defer conn.Close()
+
+			for i := 0; i < 10; i++ {
+				fmt.Fprintf(conn, "client #%d, count %d\n", id, i)
+				res, err := bufio.NewReader(conn).ReadString('\n')
+				if err != nil {
+					log.Println(err.Error())
+					return
+				}
+				log.Printf("Received: %s", res)
+				time.Sleep(100 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	// We sleep for a couple of seconds, let the clients run their jobs,
+	// then we exit, which triggers the defer function that will shutdown
+	// the server.
+	time.Sleep(2 * time.Second)
 }

--- a/sieve.go
+++ b/sieve.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"log"
-	"net"
 	"os"
 	"path"
 	"regexp"
@@ -196,15 +195,15 @@ func (p *PolicyList) getListenerAddresses() []AddrString {
 	return addrList
 }
 
-func (p *PolicyList) getAuthenticatedPolicyListeners() map[net.Listener]*SievePolicyJSONConfig {
-	listenerMap := make(map[net.Listener]*SievePolicyJSONConfig)
+func (p *PolicyList) getAuthenticatedPolicyAddresses() map[AddrString]*SievePolicyJSONConfig {
+	listenerMap := make(map[AddrString]*SievePolicyJSONConfig)
 	for _, filter := range p.loadedFilters {
 		if filter.AuthNetAddr != "" && filter.AuthAddr != "" {
-			listener, err := net.Listen(filter.AuthNetAddr, filter.AuthAddr)
-			if err != nil {
-				panic(err)
+			addrString := AddrString{
+				Net:     filter.AuthNetAddr,
+				Address: filter.AuthAddr,
 			}
-			listenerMap[listener] = filter
+			listenerMap[addrString] = filter
 		}
 	}
 	return listenerMap


### PR DESCRIPTION
This here is quite important for usage with unix domain sockets...
it ensures that future daemon starts will succeed because the socket
file from the previous run was removed upon shutdown.
