### PR TITLE
Implement privilege seperation for the procsnitch API

### DIFF
--- a/README.mdwn
+++ b/README.mdwn
@@ -52,24 +52,45 @@ After=tor.service
 
 [Service]
 Type=simple
-User=root
-Group=debian-tor
+User=roflcoptor
+Group=roflcoptor
 WorkingDirectory=/var/log/tor
 ExecStart=/usr/local/bin/roflcoptor -config /etc/roflcoptor/roflcoptor_config.json
 ```
 
-Create the directory, /etc/roflcoptor, and /etc/roflcoptor/filters for the filter rule files.
+Run roflcoptor as the roflcoptor user and group. However you must be able to read and write to
+the tor and procsnitch UNIX domain sockets. Therefore the roflcoptor user must be in the debian-tor
+and procsnitch groups. Your /etc/group file should contain entries like these:
+
+```
+debian-tor:x:111:roflcoptor
+roflcoptor:x:1001:
+procsnitch:x:1002:roflcoptor
+```
+
+Create and chown the roflcoptor related directories:
+
+```
+mkdir /etc/roflcoptor
+mkdir /etc/roflcoptor/filters
+mkdir /var/run/roflcoptor
+chown roflcoptor:roflcoptor /etc/roflcoptor
+chown roflcoptor:roflcoptor /etc/roflcoptor/filters
+chown roflcoptor:roflcoptor /var/run/roflcoptor
+```
+
 The json configuration file, /etc/roflcoptor/roflcoptor_config.json should look like this:
 
 ```
 {
+    "ProcSnitchSocketFile" : "/var/run/procsnitchd/rpc.socket",
     "FiltersPath" : "/etc/roflcoptor/filters",
     "TorControlNet" : "unix",
     "TorControlAddress" : "/var/run/tor/control",
     "Listeners" : [
 	{
 	    "Net" : "unix",
-	    "Address" : "/tmp/roflcoptor.socket"
+	    "Address" : "/var/run/roflcoptor/roflcoptor.socket"
 	},
 	{
 	    "Net" : "tcp",
@@ -79,8 +100,11 @@ The json configuration file, /etc/roflcoptor/roflcoptor_config.json should look 
 }
 ```
 
-As you can see the filter rules directory is specified in the above config file.
-The filters in this repo are to be installed in the above specified filters directory, /etc/roflcoptor/filters.
+
+The above mentioned ``ProcSnitchSocketFile`` refers to the UNIX domain socket which the procsnitch daemon is listening.
+Procsnitch daemon is essentially a privilege seperation component of roflcoptor.
+
+Please see https://github.com/subgraph/procsnitchd
 
 
 # Acknowledgements

--- a/roflcoptor.service
+++ b/roflcoptor.service
@@ -4,6 +4,6 @@ After=tor.service
 
 [Service]
 Type=simple
-User=root
-Group=debian-tor
-ExecStart=/usr/local/sbin/roflcoptor -config /etc/roflcoptor/roflcoptor_config.json
+User=roflcoptor
+Group=roflcoptor
+ExecStart=/home/user/gopath/bin/roflcoptor -watch -config /etc/roflcoptor/roflcoptor_config.json

--- a/roflcoptor_config.json
+++ b/roflcoptor_config.json
@@ -1,11 +1,12 @@
 {
+    "ProcSnitchSocketFile" : "/var/run/procsnitchd/rpc.socket",
     "FiltersPath" : "/etc/roflcoptor/filters",
     "TorControlNet" : "unix",
     "TorControlAddress" : "/var/run/tor/control",
     "Listeners" : [
 	{
 	    "Net" : "unix",
-	    "Address" : "/tmp/roflcoptor.socket"
+	    "Address" : "/var/run/roflcoptor/roflcoptor.socket"
 	},
 	{
 	    "Net" : "tcp",

--- a/session.go
+++ b/session.go
@@ -46,11 +46,11 @@ type ProxyListener struct {
 
 // NewProxyListener creates a new ProxyListener given
 // a configuration structure.
-func NewProxyListener(cfg *RoflcoptorConfig, watch bool) *ProxyListener {
+func NewProxyListener(cfg *RoflcoptorConfig, watch bool, procInfo procsnitch.ProcInfo) *ProxyListener {
 	p := ProxyListener{
 		cfg:        cfg,
 		watch:      watch,
-		procInfo:   procsnitch.SystemProcInfo{},
+		procInfo:   procInfo,
 		policyList: NewPolicyList(),
 	}
 	return &p

--- a/session_test.go
+++ b/session_test.go
@@ -111,17 +111,16 @@ func setupFakeProxyAndTorService(proxyNet, proxyAddress string, procInfo procsni
 		},
 	}
 	config := RoflcoptorConfig{
-		LogFile:           "-",
-		FiltersPath:       "./filters",
-		Listeners:         listeners,
-		TorControlNet:     "unix",
-		TorControlAddress: "test_tor_socket",
+		ProcSnitchSocketFile: "-",
+		FiltersPath:          "./filters",
+		Listeners:            listeners,
+		TorControlNet:        "unix",
+		TorControlAddress:    "test_tor_socket",
 	}
 	fakeTorService := NewAccumulatingListener(config.TorControlNet, config.TorControlAddress)
 	fakeTorService.Start()
 	watch := false
-	proxyListener := NewProxyListener(&config, watch)
-	proxyListener.procInfo = procInfo
+	proxyListener := NewProxyListener(&config, watch, procInfo)
 	proxyListener.StartListeners()
 	fmt.Println("started listeners for testing")
 	return fakeTorService, proxyListener
@@ -316,19 +315,16 @@ func TestProxyListenerWatchModeSession(t *testing.T) {
 		},
 	}
 	config := RoflcoptorConfig{
-		LogFile:           "-",
-		FiltersPath:       "./filters",
-		Listeners:         listeners,
-		TorControlNet:     "unix",
-		TorControlAddress: "test_tor_socket",
+		ProcSnitchSocketFile: "-",
+		FiltersPath:          "./filters",
+		Listeners:            listeners,
+		TorControlNet:        "unix",
+		TorControlAddress:    "test_tor_socket",
 	}
 	fakeTorService := NewAccumulatingListener(config.TorControlNet, config.TorControlAddress)
 	fakeTorService.Start()
 
 	watch := true
-	proxyService := NewProxyListener(&config, watch)
-	defer fakeTorService.Stop()
-
 	ricochetProcInfo := procsnitch.Info{
 		UID:       1,
 		Pid:       1,
@@ -336,7 +332,10 @@ func TestProxyListenerWatchModeSession(t *testing.T) {
 		ExePath:   "/usr/local/bin/ricochet",
 		CmdLine:   "testing_cmd_line",
 	}
-	proxyService.procInfo = NewMockProcInfo(&ricochetProcInfo)
+	procInfo := NewMockProcInfo(&ricochetProcInfo)
+	proxyService := NewProxyListener(&config, watch, procInfo)
+	defer fakeTorService.Stop()
+
 	proxyService.StartListeners()
 	defer proxyService.StopListeners()
 
@@ -429,11 +428,11 @@ func TestNoProtocolInfoTorControlPort(t *testing.T) {
 		},
 	}
 	config := RoflcoptorConfig{
-		LogFile:           "-",
-		FiltersPath:       "./filters",
-		Listeners:         listeners,
-		TorControlNet:     "unix",
-		TorControlAddress: "test_tor_socket",
+		ProcSnitchSocketFile: "-",
+		FiltersPath:          "./filters",
+		Listeners:            listeners,
+		TorControlNet:        "unix",
+		TorControlAddress:    "test_tor_socket",
 	}
 	fakeTorService := NewAccumulatingListener(config.TorControlNet, config.TorControlAddress)
 	fakeTorService.hasProtocolInfo = false
@@ -469,11 +468,11 @@ func TestNoAuthenticateTorControlPort(t *testing.T) {
 		},
 	}
 	config := RoflcoptorConfig{
-		LogFile:           "-",
-		FiltersPath:       "./filters",
-		Listeners:         listeners,
-		TorControlNet:     "unix",
-		TorControlAddress: "test_tor_socket",
+		ProcSnitchSocketFile: "-",
+		FiltersPath:          "./filters",
+		Listeners:            listeners,
+		TorControlNet:        "unix",
+		TorControlAddress:    "test_tor_socket",
 	}
 	fakeTorService := NewAccumulatingListener(config.TorControlNet, config.TorControlAddress)
 	fakeTorService.hasAuthenticate = false


### PR DESCRIPTION
- This code change let's roflcoptor run as non-root!
- Here we use a UNIX domain socket RPC to talk to the procsnitch daemon;
  the code change is very small and simple because we are using the ProcInfo interface.

Code review is the way of my people. Did I miss anything?
